### PR TITLE
Redesign Projects and Skills with interactive motion-driven UI

### DIFF
--- a/app/skills/page.tsx
+++ b/app/skills/page.tsx
@@ -1,21 +1,13 @@
 import { SectionWrapper } from '@/components/SectionWrapper';
-import { skills } from '@/lib/content';
+import { SkillsShowcase } from '@/components/SkillsShowcase';
 
 export default function SkillsPage() {
   return (
-    <SectionWrapper title="Skills" subtitle="Technical depth backed by communication and leadership.">
-      <div className="grid gap-5 md:grid-cols-2">
-        {Object.entries(skills).map(([category, list]) => (
-          <article key={category} className="rounded-xl border border-border bg-card p-6">
-            <h3 className="text-lg font-semibold capitalize">{category}</h3>
-            <ul className="mt-3 space-y-2 text-sm text-muted-foreground">
-              {list.map((item) => (
-                <li key={item}>• {item}</li>
-              ))}
-            </ul>
-          </article>
-        ))}
-      </div>
+    <SectionWrapper
+      title="Skills"
+      subtitle="Interactive skill matrix with category filters, animated proficiency bars, and polished micro-interactions."
+    >
+      <SkillsShowcase />
     </SectionWrapper>
   );
 }

--- a/components/ProjectCards.tsx
+++ b/components/ProjectCards.tsx
@@ -1,34 +1,100 @@
 'use client';
 
-import { motion } from 'framer-motion';
+import Image from 'next/image';
+import Link from 'next/link';
+import { motion, useMotionTemplate, useMotionValue } from 'framer-motion';
+import type { MouseEvent } from 'react';
+import { ArrowUpRight, Layers3 } from 'lucide-react';
 import { projects } from '@/lib/content';
+
+function ProjectCard({
+  project,
+  index
+}: {
+  project: (typeof projects)[number];
+  index: number;
+}) {
+  const rotateX = useMotionValue(0);
+  const rotateY = useMotionValue(0);
+  const mouseX = useMotionValue(0);
+  const mouseY = useMotionValue(0);
+  const spotlight = useMotionTemplate`radial-gradient(300px circle at ${mouseX}px ${mouseY}px, rgba(255,255,255,0.2), transparent 70%)`;
+
+  const onMove = (event: MouseEvent<HTMLElement>) => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    const x = event.clientX - rect.left;
+    const y = event.clientY - rect.top;
+    mouseX.set(x);
+    mouseY.set(y);
+    rotateX.set(((y - rect.height / 2) / rect.height) * -10);
+    rotateY.set(((x - rect.width / 2) / rect.width) * 10);
+  };
+
+  const onLeave = () => {
+    rotateX.set(0);
+    rotateY.set(0);
+  };
+
+  return (
+    <motion.article
+      initial={{ opacity: 0, y: 36 }}
+      whileInView={{ opacity: 1, y: 0 }}
+      viewport={{ once: true, amount: 0.3 }}
+      transition={{ duration: 0.55, delay: index * 0.1 }}
+      onMouseMove={onMove}
+      onMouseLeave={onLeave}
+      style={{ rotateX, rotateY, transformStyle: 'preserve-3d' }}
+      className="group relative overflow-hidden rounded-3xl border border-white/15 bg-black/80 p-5 shadow-[0_28px_80px_-45px_rgba(255,255,255,0.5)]"
+    >
+      <motion.div className="pointer-events-none absolute inset-0 opacity-0 transition-opacity duration-500 group-hover:opacity-100" style={{ background: spotlight }} />
+      <div className="absolute inset-0 bg-[linear-gradient(120deg,rgba(255,255,255,0.1),transparent_40%,transparent_60%,rgba(255,255,255,0.08))] opacity-0 transition duration-500 group-hover:opacity-100" />
+
+      <div className="relative flex h-full flex-col gap-4">
+        <div className="flex items-start justify-between">
+          <div className="rounded-2xl border border-white/20 bg-white/5 p-3 backdrop-blur-sm">
+            <Image src={project.image} alt={`${project.title} logo`} width={38} height={38} className="h-9 w-9" />
+          </div>
+          <span className="inline-flex items-center gap-2 rounded-full border border-white/20 bg-white/5 px-3 py-1 text-[11px] uppercase tracking-[0.2em] text-white/75">
+            <Layers3 className="h-3.5 w-3.5" />
+            {project.category}
+          </span>
+        </div>
+
+        <div>
+          <h3 className="text-xl font-semibold text-white md:text-2xl">{project.title}</h3>
+          <p className="mt-2 text-sm leading-relaxed text-white/70">{project.summary}</p>
+        </div>
+
+        <p className="rounded-xl border border-white/15 bg-white/[0.03] p-3 text-sm text-white/85">{project.impact}</p>
+
+        <div className="mt-auto flex flex-wrap gap-2">
+          {project.stack.map((tech) => (
+            <span
+              key={tech}
+              className="rounded-full border border-white/20 bg-white/[0.04] px-3 py-1 text-xs text-white/70 transition group-hover:border-white/40 group-hover:text-white"
+            >
+              {tech}
+            </span>
+          ))}
+        </div>
+
+        <Link
+          href={project.href ?? '/projects'}
+          className="mt-3 inline-flex w-fit items-center gap-2 text-sm font-medium text-white/80 transition hover:text-white"
+        >
+          Explore Project
+          <ArrowUpRight className="h-4 w-4 transition group-hover:translate-x-1 group-hover:-translate-y-1" />
+        </Link>
+      </div>
+    </motion.article>
+  );
+}
 
 export function ProjectCards() {
   return (
-    <div className="grid gap-6 md:grid-cols-2">
+    <div className="grid gap-6 lg:grid-cols-2">
       {projects.map((project, index) => (
-        <motion.article
-          key={project.title}
-          initial={{ opacity: 0, y: 30 }}
-          whileInView={{ opacity: 1, y: 0 }}
-          viewport={{ once: true }}
-          transition={{ delay: index * 0.08, duration: 0.5 }}
-          whileHover={{ rotateX: -6, rotateY: 6, scale: 1.02 }}
-          className="group relative transform-gpu rounded-2xl border border-border bg-card/70 p-6 shadow-[0_10px_50px_rgba(0,0,0,0.25)] transition duration-300 [transform-style:preserve-3d]"
-        >
-          <div className="absolute inset-0 rounded-2xl bg-gradient-to-br from-white/10 via-transparent to-slate-300/10 opacity-0 transition group-hover:opacity-100" />
-          <p className="relative text-xs uppercase tracking-[0.2em] text-muted-foreground">{project.category}</p>
-          <h3 className="relative mt-2 text-2xl font-semibold text-foreground">{project.title}</h3>
-          <p className="relative mt-3 text-sm leading-relaxed text-muted-foreground">{project.summary}</p>
-          <p className="relative mt-4 text-sm text-foreground/90">{project.impact}</p>
-          <div className="relative mt-5 flex flex-wrap gap-2">
-            {project.stack.map((tech) => (
-              <span key={tech} className="rounded-full border border-border px-3 py-1 text-xs text-muted-foreground">
-                {tech}
-              </span>
-            ))}
-          </div>
-        </motion.article>
+        <ProjectCard key={project.title} project={project} index={index} />
       ))}
     </div>
   );

--- a/components/SkillsShowcase.tsx
+++ b/components/SkillsShowcase.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import { motion } from 'framer-motion';
+import { Bolt, Cpu, Hammer, TerminalSquare } from 'lucide-react';
+import type { SkillCategory } from '@/lib/content';
+import { skills } from '@/lib/content';
+
+const categories: SkillCategory[] = ['Programming', 'Hardware', 'Tools', 'Leadership'];
+
+const iconByCategory = {
+  Programming: TerminalSquare,
+  Hardware: Cpu,
+  Tools: Hammer,
+  Leadership: Bolt
+} as const;
+
+export function SkillsShowcase() {
+  const [activeCategory, setActiveCategory] = useState<SkillCategory>('Programming');
+
+  const filteredSkills = useMemo(
+    () => skills.filter((skill) => skill.category === activeCategory),
+    [activeCategory]
+  );
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-wrap gap-3">
+        {categories.map((category) => {
+          const Icon = iconByCategory[category];
+          const active = category === activeCategory;
+
+          return (
+            <button
+              key={category}
+              onClick={() => setActiveCategory(category)}
+              className={`inline-flex items-center gap-2 rounded-full border px-4 py-2 text-sm transition ${
+                active
+                  ? 'border-white/60 bg-white text-black shadow-[0_8px_24px_-12px_rgba(255,255,255,0.8)]'
+                  : 'border-white/25 bg-black/50 text-white/75 hover:border-white/45 hover:text-white'
+              }`}
+              type="button"
+            >
+              <Icon className="h-4 w-4" />
+              {category}
+            </button>
+          );
+        })}
+      </div>
+
+      <motion.div
+        key={activeCategory}
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+        className="grid gap-4 md:grid-cols-2"
+      >
+        {filteredSkills.map((skill, index) => (
+          <motion.article
+            key={skill.name}
+            initial={{ opacity: 0, y: 24 }}
+            whileInView={{ opacity: 1, y: 0 }}
+            viewport={{ once: true, amount: 0.3 }}
+            transition={{ delay: index * 0.08, duration: 0.45 }}
+            whileHover={{ y: -4 }}
+            className="group rounded-2xl border border-white/15 bg-white/[0.03] p-4 shadow-[0_18px_45px_-35px_rgba(255,255,255,0.7)]"
+          >
+            <div className="flex items-center justify-between">
+              <p className="text-sm font-medium text-white">{skill.name}</p>
+              <span className="text-xs text-white/60">{skill.level}%</span>
+            </div>
+            <div className="mt-3 h-2 overflow-hidden rounded-full bg-white/10">
+              <motion.div
+                initial={{ width: 0 }}
+                whileInView={{ width: `${skill.level}%` }}
+                viewport={{ once: true }}
+                transition={{ duration: 0.65, delay: 0.08 * index + 0.1, ease: 'easeOut' }}
+                className="h-full rounded-full bg-gradient-to-r from-white/90 via-white to-white/70"
+              />
+            </div>
+          </motion.article>
+        ))}
+      </motion.div>
+    </div>
+  );
+}

--- a/lib/content.ts
+++ b/lib/content.ts
@@ -29,14 +29,26 @@ export const experiences = [
   }
 ];
 
-export const projects = [
+export type Project = {
+  title: string;
+  category: string;
+  summary: string;
+  stack: string[];
+  impact: string;
+  image: string;
+  href?: string;
+};
+
+export const projects: Project[] = [
   {
     title: 'VaaniConnect',
     category: 'AI + Language Accessibility',
     summary:
       'AI-powered Indian-language translation app designed to improve communication and inclusion across linguistic communities.',
     stack: ['Next.js', 'TypeScript', 'AI APIs', 'Figma'],
-    impact: 'Design Lead working directly with KL University team in India.'
+    impact: 'Design Lead working directly with KL University team in India.',
+    image: '/gallery/brand-1.svg',
+    href: '/projects'
   },
   {
     title: 'Purdue 300 mm Onboarding Rocket',
@@ -44,7 +56,9 @@ export const projects = [
     summary:
       'End-to-end rocket subsystem contributions with NX CAD, OpenRocket simulation, Excel flight model analysis, and 3D-printed parts.',
     stack: ['Siemens NX', 'OpenRocket', 'Excel', '3D Printing'],
-    impact: 'Improved design reliability and test-readiness for onboarding workflows.'
+    impact: 'Improved design reliability and test-readiness for onboarding workflows.',
+    image: '/gallery/rocket-1.svg',
+    href: '/gallery'
   },
   {
     title: 'Organization & Client Websites',
@@ -52,7 +66,9 @@ export const projects = [
     summary:
       'Multiple custom websites for organizations and clients with clean UI systems, SEO-minded architecture, and conversion-focused layouts.',
     stack: ['Next.js', 'Tailwind', 'Framer Motion', 'Vercel'],
-    impact: 'Strengthened brand credibility and digital presence for stakeholders.'
+    impact: 'Strengthened brand credibility and digital presence for stakeholders.',
+    image: '/gallery/project-1.svg',
+    href: '/projects'
   },
   {
     title: 'AI / Gesture / Automation Lab',
@@ -60,16 +76,38 @@ export const projects = [
     summary:
       'Exploratory systems combining computer vision, gesture control, and automation for practical everyday interactions.',
     stack: ['Python', 'OpenCV', 'TensorFlow', 'Node.js'],
-    impact: 'Rapid prototyping discipline and experimentation mindset.'
+    impact: 'Rapid prototyping discipline and experimentation mindset.',
+    image: '/gallery/rocket-2.svg',
+    href: '/projects'
   }
 ];
 
-export const skills = {
-  engineering: ['Computer Engineering', 'Systems Thinking', 'Rapid Prototyping', 'Simulation'],
-  software: ['Next.js', 'TypeScript', 'React', 'Tailwind CSS', 'Framer Motion', 'Node.js'],
-  ai: ['Prompt Engineering', 'Applied AI Integrations', 'Computer Vision', 'Automation'],
-  leadership: ['Design Leadership', 'Cross-Cultural Collaboration', 'Mentorship', 'Project Planning']
+export type SkillCategory = 'Programming' | 'Hardware' | 'Tools' | 'Leadership';
+
+export type SkillItem = {
+  name: string;
+  category: SkillCategory;
+  level: number;
 };
+
+export const skills: SkillItem[] = [
+  { name: 'TypeScript', category: 'Programming', level: 92 },
+  { name: 'React / Next.js', category: 'Programming', level: 90 },
+  { name: 'Python', category: 'Programming', level: 84 },
+  { name: 'Computer Vision', category: 'Programming', level: 78 },
+  { name: 'Siemens NX CAD', category: 'Hardware', level: 80 },
+  { name: 'OpenRocket', category: 'Hardware', level: 76 },
+  { name: '3D Printing Workflow', category: 'Hardware', level: 82 },
+  { name: 'Embedded Prototyping', category: 'Hardware', level: 72 },
+  { name: 'Tailwind CSS', category: 'Tools', level: 88 },
+  { name: 'Framer Motion', category: 'Tools', level: 84 },
+  { name: 'Figma', category: 'Tools', level: 86 },
+  { name: 'Vercel + GitHub', category: 'Tools', level: 83 },
+  { name: 'Design Leadership', category: 'Leadership', level: 88 },
+  { name: 'Cross-Cultural Collaboration', category: 'Leadership', level: 90 },
+  { name: 'Mentorship', category: 'Leadership', level: 82 },
+  { name: 'Project Planning', category: 'Leadership', level: 85 }
+];
 
 export const socialLinks = {
   github: 'https://github.com/ichiro-okochi',


### PR DESCRIPTION
### Motivation
- Upgrade the Projects and Skills pages from simple lists into an animated, high-impact, and professional-looking experience that fits the black/white hacker-style theme.  
- Introduce motion-driven micro-interactions and responsive layouts to increase visual depth and engagement while keeping the UI minimal and elegant.

### Description
- Implemented a new `ProjectCard` system inside `components/ProjectCards.tsx` with tilt/3D rotation, mouse-driven spotlight, logo imagery, tech chips, and a project CTA using `framer-motion` and `next/image`.  
- Added a reusable `SkillsShowcase` component in `components/SkillsShowcase.tsx` providing category filter pills, icon-backed filters (via `lucide-react`), and animated proficiency bars with staggered on-scroll reveals.  
- Extended the content model in `lib/content.ts` with typed `Project` and `SkillItem` types and populated each project with `image` and optional `href`, and each skill with `category` and numeric `level`.  
- Wired the Skills page to the new showcase by updating `app/skills/page.tsx` to render `SkillsShowcase`, and adjusted grid/layout classes for responsive behavior using Tailwind CSS utilities.

### Testing
- Ran `npm run lint`, which failed in this environment with `next: not found` because dependencies were not installed.  
- Attempted `npm install`, which failed due to the environment returning an npm registry `403 Forbidden`, preventing dependency installation and local build/lint verification.  
- Commit recorded locally as part of the change set (files changed: `components/ProjectCards.tsx`, `components/SkillsShowcase.tsx` (new), `lib/content.ts`, `app/skills/page.tsx`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b7fa66ec483329454ce3bce329df5)