### PR TITLE
Add gallery SVG assets referenced in content

### DIFF
--- a/public/gallery/brand-1.svg
+++ b/public/gallery/brand-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Brand Project Placeholder</title>
+  <desc id="desc">Abstract gradient card representing a branding project.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0%" stop-color="#1E3A8A"/>
+      <stop offset="100%" stop-color="#9333EA"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg)" rx="32"/>
+  <rect x="120" y="120" width="560" height="360" rx="28" fill="rgba(255,255,255,0.14)"/>
+  <circle cx="240" cy="220" r="48" fill="#FDE68A"/>
+  <rect x="320" y="190" width="280" height="22" rx="11" fill="#E0E7FF"/>
+  <rect x="320" y="228" width="220" height="18" rx="9" fill="#C7D2FE"/>
+  <rect x="200" y="320" width="400" height="24" rx="12" fill="#F5F3FF"/>
+  <rect x="200" y="360" width="300" height="18" rx="9" fill="#DDD6FE"/>
+</svg>

--- a/public/gallery/project-1.svg
+++ b/public/gallery/project-1.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Web Project Placeholder</title>
+  <desc id="desc">A browser mockup representing web development work.</desc>
+  <rect width="800" height="600" fill="#F1F5F9"/>
+  <rect x="90" y="80" width="620" height="440" rx="20" fill="#FFFFFF" stroke="#CBD5E1" stroke-width="6"/>
+  <rect x="90" y="80" width="620" height="56" rx="20" fill="#E2E8F0"/>
+  <circle cx="128" cy="108" r="8" fill="#EF4444"/>
+  <circle cx="156" cy="108" r="8" fill="#F59E0B"/>
+  <circle cx="184" cy="108" r="8" fill="#22C55E"/>
+  <rect x="130" y="170" width="260" height="22" rx="11" fill="#0F172A"/>
+  <rect x="130" y="208" width="420" height="14" rx="7" fill="#94A3B8"/>
+  <rect x="130" y="234" width="360" height="14" rx="7" fill="#CBD5E1"/>
+  <rect x="130" y="280" width="540" height="140" rx="16" fill="#DBEAFE"/>
+  <rect x="150" y="304" width="170" height="18" rx="9" fill="#1D4ED8"/>
+  <rect x="150" y="334" width="220" height="12" rx="6" fill="#60A5FA"/>
+  <rect x="150" y="356" width="180" height="12" rx="6" fill="#93C5FD"/>
+  <rect x="590" y="170" width="80" height="28" rx="14" fill="#2563EB"/>
+</svg>

--- a/public/gallery/rocket-1.svg
+++ b/public/gallery/rocket-1.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Rocket Engineering Project Placeholder</title>
+  <desc id="desc">Stylized rocket launch illustration.</desc>
+  <rect width="800" height="600" fill="#0B1023"/>
+  <circle cx="130" cy="120" r="3" fill="#fff"/>
+  <circle cx="260" cy="80" r="2" fill="#fff"/>
+  <circle cx="680" cy="140" r="2.5" fill="#fff"/>
+  <circle cx="720" cy="70" r="2" fill="#fff"/>
+  <path d="M400 140c86 42 120 135 120 220H280c0-85 34-178 120-220Z" fill="#1D4ED8"/>
+  <rect x="360" y="180" width="80" height="220" rx="40" fill="#E5E7EB"/>
+  <polygon points="400,120 350,200 450,200" fill="#93C5FD"/>
+  <circle cx="400" cy="250" r="24" fill="#2563EB"/>
+  <polygon points="360,320 320,370 360,370" fill="#60A5FA"/>
+  <polygon points="440,320 480,370 440,370" fill="#60A5FA"/>
+  <polygon points="370,400 430,400 400,500" fill="#F97316"/>
+  <polygon points="380,400 420,400 400,460" fill="#FCD34D"/>
+</svg>

--- a/public/gallery/rocket-2.svg
+++ b/public/gallery/rocket-2.svg
@@ -1,0 +1,29 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 800 600" role="img" aria-labelledby="title desc">
+  <title id="title">Research and Automation Placeholder</title>
+  <desc id="desc">Geometric pattern suggesting AI and automation experiments.</desc>
+  <defs>
+    <linearGradient id="bg2" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#022C22"/>
+      <stop offset="100%" stop-color="#0F766E"/>
+    </linearGradient>
+  </defs>
+  <rect width="800" height="600" fill="url(#bg2)"/>
+  <g fill="none" stroke="#5EEAD4" stroke-width="4" opacity="0.8">
+    <circle cx="220" cy="180" r="70"/>
+    <circle cx="400" cy="300" r="110"/>
+    <circle cx="600" cy="210" r="80"/>
+  </g>
+  <g fill="#99F6E4">
+    <circle cx="220" cy="180" r="10"/>
+    <circle cx="400" cy="300" r="12"/>
+    <circle cx="600" cy="210" r="10"/>
+    <circle cx="330" cy="390" r="8"/>
+    <circle cx="510" cy="390" r="8"/>
+  </g>
+  <g stroke="#CCFBF1" stroke-width="3">
+    <line x1="220" y1="180" x2="400" y2="300"/>
+    <line x1="400" y1="300" x2="600" y2="210"/>
+    <line x1="400" y1="300" x2="330" y2="390"/>
+    <line x1="400" y1="300" x2="510" y2="390"/>
+  </g>
+</svg>


### PR DESCRIPTION
### Motivation
- Ensure static image paths referenced by the site (`/gallery/*.svg`) exist so project cards and other UI that expect these assets render correctly; no code was modified and no skills were used.

### Description
- Create `public/gallery` and add four SVG placeholders matching the references in `lib/content.ts`: `brand-1.svg`, `rocket-1.svg`, `project-1.svg`, and `rocket-2.svg`.

### Testing
- Verified files are present with `find public -maxdepth 2 -type f | sort` and confirmed all `/gallery/*.svg` references in `lib/content.ts` resolve using `rg`, and both checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b8654235c8332afa3526d36ac2826)