### PR TITLE
Add interactive Three.js-powered hero background

### DIFF
--- a/components/AnimatedBackground.tsx
+++ b/components/AnimatedBackground.tsx
@@ -1,20 +1,31 @@
 'use client';
 
-import { motion, useScroll, useTransform } from 'framer-motion';
+import Script from 'next/script';
+import { useEffect, useRef, useState } from 'react';
+import { createHeroScene } from '@/lib/threeHeroScene';
 
 export function AnimatedBackground() {
-  const { scrollYProgress } = useScroll();
-  const y = useTransform(scrollYProgress, [0, 1], [0, -180]);
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const [threeReady, setThreeReady] = useState(false);
+
+  useEffect(() => {
+    if (!threeReady || !canvasRef.current) {
+      return;
+    }
+
+    const controller = createHeroScene(canvasRef.current);
+    return () => controller.dispose();
+  }, [threeReady]);
 
   return (
-    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden">
-      <motion.div
-        style={{ y }}
-        className="absolute inset-0 bg-[radial-gradient(circle_at_top,_rgba(255,255,255,0.08),_transparent_42%),radial-gradient(circle_at_80%_20%,_rgba(148,163,184,0.15),_transparent_36%)]"
+    <div className="pointer-events-none fixed inset-0 -z-10 overflow-hidden bg-[#0b0b0f]">
+      <Script
+        src="https://unpkg.com/three@0.173.0/build/three.min.js"
+        strategy="afterInteractive"
+        onLoad={() => setThreeReady(true)}
       />
-      <div className="absolute inset-0 animate-pulse-grid bg-[linear-gradient(rgba(255,255,255,0.03)_1px,transparent_1px),linear-gradient(90deg,rgba(255,255,255,0.03)_1px,transparent_1px)] bg-[size:48px_48px]" />
-      <div className="absolute -left-24 top-1/4 h-72 w-72 rounded-full bg-white/5 blur-3xl" />
-      <div className="absolute -right-24 bottom-1/4 h-72 w-72 rounded-full bg-slate-300/10 blur-3xl" />
+      <canvas ref={canvasRef} className="h-full w-full" aria-hidden="true" />
+      <div className="absolute inset-0 bg-[radial-gradient(circle_at_18%_20%,rgba(34,211,238,0.12),transparent_34%),radial-gradient(circle_at_84%_76%,rgba(168,85,247,0.14),transparent_36%),linear-gradient(to_bottom,rgba(11,11,15,0.08),rgba(11,11,15,0.4)_70%,rgba(11,11,15,0.7))]" />
     </div>
   );
 }

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -9,7 +9,7 @@ import { SocialIcons } from './SocialIcons';
 
 export function Hero() {
   return (
-    <section className="mx-auto flex min-h-[72vh] w-full max-w-6xl flex-col justify-center px-6 py-20 md:px-10">
+    <section className="relative z-10 mx-auto flex min-h-[72vh] w-full max-w-6xl flex-col justify-center px-6 py-20 md:px-10">
       <motion.p initial={{ opacity: 0 }} animate={{ opacity: 1 }} className="text-sm uppercase tracking-[0.22em] text-muted-foreground">
         {profile.major}
       </motion.p>

--- a/lib/threeHeroScene.ts
+++ b/lib/threeHeroScene.ts
@@ -1,0 +1,154 @@
+type HeroSceneController = {
+  dispose: () => void;
+};
+
+declare global {
+  interface Window {
+    THREE?: any;
+  }
+}
+
+const pointer = { x: 0, y: 0 };
+const NEON_COLORS = ['#4f46e5', '#22d3ee', '#a855f7', '#60a5fa'];
+
+export function createHeroScene(canvas: HTMLCanvasElement): HeroSceneController {
+  const THREE = window.THREE;
+
+  if (!THREE) {
+    return { dispose: () => undefined };
+  }
+
+  const renderer = new THREE.WebGLRenderer({
+    canvas,
+    antialias: true,
+    alpha: true,
+    powerPreference: 'high-performance'
+  });
+
+  renderer.setPixelRatio(Math.min(window.devicePixelRatio, 1.8));
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  renderer.setClearColor(new THREE.Color('#0b0b0f'), 1);
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(55, window.innerWidth / window.innerHeight, 0.1, 100);
+  camera.position.set(0, 0.4, 9.5);
+
+  const ambientLight = new THREE.AmbientLight('#94a3ff', 0.4);
+  const keyLight = new THREE.PointLight('#60a5fa', 1.1, 30);
+  const rimLight = new THREE.PointLight('#c084fc', 0.8, 20);
+  keyLight.position.set(4, 2, 8);
+  rimLight.position.set(-5, -2, 4);
+  scene.add(ambientLight, keyLight, rimLight);
+
+  const group = new THREE.Group();
+  scene.add(group);
+
+  const sphereGeometry = new THREE.IcosahedronGeometry(0.6, 1);
+  const boxGeometry = new THREE.BoxGeometry(0.7, 0.7, 0.7);
+  const torusGeometry = new THREE.TorusGeometry(0.55, 0.14, 16, 60);
+
+  for (let i = 0; i < 26; i += 1) {
+    const material = new THREE.MeshStandardMaterial({
+      color: new THREE.Color(NEON_COLORS[i % NEON_COLORS.length]),
+      emissive: new THREE.Color(NEON_COLORS[(i + 1) % NEON_COLORS.length]),
+      emissiveIntensity: 0.5,
+      wireframe: i % 3 === 0,
+      metalness: 0.35,
+      roughness: 0.25
+    });
+
+    const geometry = i % 3 === 0 ? torusGeometry : i % 2 === 0 ? sphereGeometry : boxGeometry;
+    const mesh = new THREE.Mesh(geometry, material);
+
+    mesh.position.set((Math.random() - 0.5) * 18, (Math.random() - 0.5) * 10, (Math.random() - 0.5) * 12);
+    mesh.rotation.set(Math.random() * Math.PI, Math.random() * Math.PI, 0);
+    mesh.scale.setScalar(0.4 + Math.random() * 0.6);
+
+    group.add(mesh);
+  }
+
+  const particleCount = 340;
+  const positions = new Float32Array(particleCount * 3);
+  for (let i = 0; i < particleCount * 3; i += 3) {
+    positions[i] = (Math.random() - 0.5) * 34;
+    positions[i + 1] = (Math.random() - 0.5) * 18;
+    positions[i + 2] = (Math.random() - 0.5) * 26;
+  }
+
+  const particlesGeometry = new THREE.BufferGeometry();
+  particlesGeometry.setAttribute('position', new THREE.BufferAttribute(positions, 3));
+
+  const particlesMaterial = new THREE.PointsMaterial({
+    color: '#8be9fd',
+    size: 0.06,
+    transparent: true,
+    opacity: 0.8,
+    blending: THREE.AdditiveBlending,
+    depthWrite: false
+  });
+
+  const particles = new THREE.Points(particlesGeometry, particlesMaterial);
+  scene.add(particles);
+
+  const navWithMemory = navigator as Navigator & { deviceMemory?: number };
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  const lowPowerDevice =
+    (navigator.hardwareConcurrency && navigator.hardwareConcurrency <= 4) ||
+    (typeof navWithMemory.deviceMemory === 'number' && (navWithMemory.deviceMemory ?? 0) <= 4);
+  const animationScale = reduceMotion || lowPowerDevice ? 0.35 : 1;
+
+  let rafId = 0;
+  const clock = new THREE.Clock();
+
+  const onResize = () => {
+    camera.aspect = window.innerWidth / window.innerHeight;
+    camera.updateProjectionMatrix();
+    renderer.setSize(window.innerWidth, window.innerHeight);
+  };
+
+  const onPointerMove = (event: PointerEvent) => {
+    pointer.x = (event.clientX / window.innerWidth) * 2 - 1;
+    pointer.y = -(event.clientY / window.innerHeight) * 2 + 1;
+  };
+
+  window.addEventListener('resize', onResize);
+  window.addEventListener('pointermove', onPointerMove, { passive: true });
+
+  const animate = () => {
+    const elapsed = clock.getElapsedTime();
+
+    group.rotation.y = THREE.MathUtils.lerp(group.rotation.y, pointer.x * 0.2, 0.04);
+    group.rotation.x = THREE.MathUtils.lerp(group.rotation.x, pointer.y * 0.12, 0.04);
+
+    group.children.forEach((mesh: any, index: number) => {
+      mesh.rotation.x += 0.0018 * animationScale;
+      mesh.rotation.y += 0.0025 * animationScale;
+      mesh.position.y += Math.sin(elapsed * 0.55 + index * 0.3) * 0.0016 * animationScale;
+      mesh.position.x += Math.cos(elapsed * 0.45 + index * 0.1) * 0.0008 * animationScale;
+    });
+
+    particles.rotation.y += 0.00045 * animationScale;
+    particles.rotation.x = THREE.MathUtils.lerp(particles.rotation.x, pointer.y * 0.08, 0.05);
+
+    renderer.render(scene, camera);
+    rafId = requestAnimationFrame(animate);
+  };
+
+  animate();
+
+  return {
+    dispose: () => {
+      cancelAnimationFrame(rafId);
+      window.removeEventListener('resize', onResize);
+      window.removeEventListener('pointermove', onPointerMove);
+
+      sphereGeometry.dispose();
+      boxGeometry.dispose();
+      torusGeometry.dispose();
+      particlesGeometry.dispose();
+      particlesMaterial.dispose();
+      group.children.forEach((child: any) => child.material?.dispose?.());
+      renderer.dispose();
+    }
+  };
+}


### PR DESCRIPTION
### Motivation
- Replace the previous dark spotlight/grid backdrop with a modern, interactive 3D hero background to make the landing section more memorable and contemporary.
- Provide subtle mouse-driven interactivity and smooth idle animation while keeping readability and performance as priorities.

### Description
- Added a modular scene initializer `createHeroScene` in `lib/threeHeroScene.ts` that builds a Three.js scene with neon emissive/wireframe geometric meshes, additive particles, soft lighting, pointer-driven tilt, responsive resizing, reduced-motion/low-power scaling, and a clean `dispose` lifecycle.
- Replaced the previous background component with `components/AnimatedBackground.tsx` that injects Three.js via CDN using `next/script`, mounts a full-screen `<canvas>` behind content, and overlays dark neon gradients for readability.
- Ensured foreground content remains readable by updating the hero wrapper to `relative z-10` in `components/Hero.tsx` so text and CTA elements render above the canvas.
- Implemented a graceful fallback where the scene initializer is a no-op if Three.js fails to load in the environment.

### Testing
- `npm run build` completed successfully and the production build was generated without errors.
- `npm run lint` was attempted but hit Next.js' first-run interactive ESLint setup prompt in this non-interactive environment and could not complete.
- A local dev server (`npm run dev`) was started and a headless Playwright screenshot of the landing page was captured to validate the new hero rendering visually.
- `npm install three@^0.173.0` failed in this environment due to a registry `403` so the implementation intentionally loads Three.js from a CDN (`unpkg`) at runtime as a fallback.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aa86c8472c83329d86bad3c9a5a999)